### PR TITLE
Map fallback location

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v0.14.0
+- Add upload progress bar
+- Update edit player from native video to <player> directive
+- On edit, redirect to video detail page
+- Added progress bar in FTP distribution proccess
+
 v0.13.1
 - Fix Vimojo favicon
 - Improve naming in browser tab

--- a/RELEASE
+++ b/RELEASE
@@ -1,5 +1,2 @@
-v0.14.0
-- Add upload progress bar
-- Update edit player from narive video to <player> directive
-- On edit, redirect to video detail page
-- Added progress bar in FTP distribution proccess
+v0.14.1
+- Set fallback location on video edit map

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimojo-platform-frontend",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Frontend for Vimojo Platform",
   "main": "gulpfile.js",
   "scripts": {

--- a/pages/video-detail-edit/partials/video-map.html
+++ b/pages/video-detail-edit/partials/video-map.html
@@ -9,7 +9,7 @@
 			   types="EditCtrl.placeTypes"
 			   on-place-changed="EditCtrl.placeChanged()">
 	</md-input-container>
-	<ng-map default-style="true" center="current-location" on-click="EditCtrl.mapClick($event)">
+	<ng-map default-style="true" center="current-location" geo-fallback-center="[40.41, -3.70]" on-click="EditCtrl.mapClick($event)">
 		<info-window position="current-location">
 			<span>{{ 'VIDEO_EDIT_GOT_BROWSER_LOCATION' | translate }}</span>
 		</info-window>


### PR DESCRIPTION
### User Story info
**ID**: 157834212
**Link**: https://www.pivotaltracker.com/story/show/157834212

### Description
There was not only a SSL thing, but a fallback place to use until the user gives permission, or if location permission is denied.

 - Added geo-fallback property to `<ng-map>` directive in *video-edit* page.

### Deployment to test:
http://35.190.182.217/gallery